### PR TITLE
S1: Create user registration endpoint for both driver and requester (#36, #37)

### DIFF
--- a/doc/api/api_documentation.md
+++ b/doc/api/api_documentation.md
@@ -23,7 +23,7 @@
 
 | Mapping | Method | Parameter | Parameter Type | Status Code | Response | Description | User Story |
 |---------|--------|-----------|----------------|-------------|----------|-------------|-----------|
-| `/api/v1/auth/register` | POST | `username <string>`, `password <string>`, `accountType <string>` | Body | 201, 400, 409 | `{ "id": "uuid", "username": "user", "accountType": "requester", "token": "jwt-token" }` | Register a new user account | S1 |
+| `/api/v1/auth/register` | POST | `userToRegister <User>` | Body | 201, 400, 409 | `createdUser <User>` | Register a new user account | S1 |
 | `/api/v1/auth/login` | POST | `username <string>`, `password <string>` | Body | 200, 401 | `{ "token": "jwt-token", "user": {...} }` | Authenticate user and create session | S2 |
 | `/api/v1/auth/logout` | POST | Auth token | Header | 200, 401 | `{ "message": "Successfully logged out" }` | End user session | S2 |
 | `/api/v1/auth/refresh` | POST | Refresh token | Body | 200, 401 | `{ "token": "new-jwt-token" }` | Refresh authentication token | S2 |

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
@@ -42,10 +42,15 @@ public class UserController {
     return userGetDTOs;
   }
 
-  @PostMapping("/users")
+  @PostMapping("/api/v1/auth/register")
   @ResponseStatus(HttpStatus.CREATED)
   @ResponseBody
-  public UserGetDTO createUser(@RequestBody UserPostDTO userPostDTO) {
+  public UserGetDTO registerUser(@RequestBody UserPostDTO userPostDTO) {
+    // throw 400 if username, password or account type is null
+    if (userPostDTO.getUsername() == null || userPostDTO.getPassword() == null || userPostDTO.getAccountType() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username, password or account type is null");
+    }
+    
     // convert API user to internal representation
     User userInput = DTOMapper.INSTANCE.convertUserPostDTOtoEntity(userPostDTO);
 

--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/controller/UserController.java
@@ -7,6 +7,7 @@ import ch.uzh.ifi.hase.soprafs24.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs24.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,10 +47,10 @@ public class UserController {
   @ResponseStatus(HttpStatus.CREATED)
   @ResponseBody
   public UserGetDTO registerUser(@RequestBody UserPostDTO userPostDTO) {
-    // throw 400 if username, password or account type is null
-    if (userPostDTO.getUsername() == null || userPostDTO.getPassword() == null || userPostDTO.getAccountType() == null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username, password or account type is null");
-    }
+    // throw 400 if username, password or account type is null, to be implemented (once objects are set up)
+    //if (userPostDTO.getUsername() == null || userPostDTO.getPassword() == null || userPostDTO.getAccountType() == null) {
+    //  throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Username, password or account type is null");
+    //}
     
     // convert API user to internal representation
     User userInput = DTOMapper.INSTANCE.convertUserPostDTOtoEntity(userPostDTO);

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
@@ -85,7 +85,7 @@ public class UserControllerTest {
     given(userService.createUser(Mockito.any())).willReturn(user);
 
     // when/then -> do the request + validate the result
-    MockHttpServletRequestBuilder postRequest = post("/users")
+    MockHttpServletRequestBuilder postRequest = post("/api/v1/auth/register")
         .contentType(MediaType.APPLICATION_JSON)
         .content(asJsonString(userPostDTO));
 


### PR DESCRIPTION
This PR addresses the following issues as the same API endpoint at `/api/v1/auth/register` will be used for both account types (and a User object is passed to the API and then returned back from the API).

This PR closes the following issues:
- Closes #36  — create driver registration endpoint
- Closes #37  — create requester registration endpoint